### PR TITLE
Fix switch fall-through in crn_decompress_block

### DIFF
--- a/unity-etc1s-crn/crnlib/crnlib.cpp
+++ b/unity-etc1s-crn/crnlib/crnlib.cpp
@@ -405,6 +405,8 @@ bool crn_decompress_block(const void *pSrc_block, crn_uint32 *pDst_pixels_u32, c
             pDst_pixels[i] = colors[s];
             pDst_pixels[i].a = static_cast<uint8>(values[a]);
          }
+
+	 break;
       }
 
       case cCRNFmtDXN_XY:


### PR DESCRIPTION
This error is quite far off the beaten path, in the crn_decompress_block() functionality, but it did confound me for a bit. Copy of https://github.com/Unity-Technologies/crunch/pull/11/commits/785e3ff4e9291b554de8cc91f2d4774455d16a1e.
